### PR TITLE
Don't copy any .git directory.

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,9 @@ func generate(templateDir string, outputDir string, mappings map[string]interfac
 	copyFile := func(filename string, info os.FileInfo, err error) error {
 		newPath := newFilename(templateDir, outputDir, filename, mappings)
 		if !info.IsDir() {
+			if strings.Contains(filename, "/.git/") {
+				return nil
+			}
 			if !force {
 				if interactive && !fileExists(newPath) {
 					if !prompt("Create " + newPath) {


### PR DESCRIPTION
When using goose with a local template dir which has a local .git dir,
goose will attempt (and usually fail) to process all files in the .git dir.

When using goose, you also don't want the template's .git dir at all
to be copied.
